### PR TITLE
Add dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Add a version of `maven-javadoc-plugin` to remove warnings in the building stage.