### PR TITLE
Add sleep time for client polling message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.sqlflow</groupId>
     <artifactId>jsqlflow</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <name>jsqlflow</name>
     <description>SQLFlow client</description>
     <url>https://github.com/sql-machine-learning/jsqlflow</url>


### PR DESCRIPTION
Our e2e test sometime fail with, it may caused by we polling the info too fast, so we add some sleep time.
```
 UNKNOWN: getCurrentStepGroup: checkNodeType failed Steps(expected) != (actual)
```